### PR TITLE
Throw exception in case of empty token.

### DIFF
--- a/src/Traits/VerifyTrait.php
+++ b/src/Traits/VerifyTrait.php
@@ -5,7 +5,7 @@ trait VerifyTrait
 {
     /**
      * Get token
-
+     *
      * @param string|null $token Token
      * @return string|null Token if found or null
      */
@@ -31,11 +31,15 @@ trait VerifyTrait
     /**
      * Verify token
      *
-     * @param string $token Token
+     * @param string $token Token.
      * @return \Cake\Datasource\EntityTrait|null
      */
-    protected function _verify($token = null)
+    protected function _verify($token)
     {
+        if (empty($token)) {
+            $this->_tokenError();
+        }
+
         $subject = $this->_subject();
         $subject->set([
             'token' => $token,
@@ -52,23 +56,34 @@ trait VerifyTrait
         $this->_trigger('beforeFind', $subject);
         $entity = $subject->query->first();
 
-        $error = 'tokenNotFound';
-        if ($entity) {
-            $subject->set(['entity' => $entity]);
-            $this->_trigger('afterFind', $subject);
-
-            if (!isset($subject->verified)) {
-                $subject->set(['verified' => false]);
-            }
-            $this->_trigger('verifyToken', $subject);
-            if ($subject->verified) {
-                return $subject->entity;
-            }
-
-            $error = 'tokenExpired';
+        if (empty($token)) {
+            $this->_tokenError();
         }
 
-        $subject->set(['success' => false]);
+        $subject->set(['entity' => $entity]);
+        $this->_trigger('afterFind', $subject);
+
+        if (!isset($subject->verified)) {
+            $subject->set(['verified' => false]);
+        }
+        $this->_trigger('verifyToken', $subject);
+
+        if ($subject->verified) {
+            return $subject->entity;
+        }
+
+        $this->_tokenError('tokenExpired');
+    }
+
+    /**
+     * Throw exception if token not found or expired.
+     *
+     * @param string $error Error type. Default "tokenNotFound"
+     * @throws \Exception
+     */
+    protected function _tokenError($error = 'tokenNotFound')
+    {
+        $subject = $this->_subject(['success' => false]);
         $this->_trigger($error, $subject);
 
         $message = $this->message($error, compact('token'));

--- a/src/Traits/VerifyTrait.php
+++ b/src/Traits/VerifyTrait.php
@@ -79,6 +79,7 @@ trait VerifyTrait
      * Throw exception if token not found or expired.
      *
      * @param string $error Error type. Default "tokenNotFound"
+     * @return void
      * @throws \Exception
      */
     protected function _tokenError($error = 'tokenNotFound')


### PR DESCRIPTION
Querying with null token doesn't make sense. It could actually cause errors.