### PR TITLE
Default Crud.ApiListener support

### DIFF
--- a/src/Action/RegisterAction.php
+++ b/src/Action/RegisterAction.php
@@ -27,6 +27,21 @@ class RegisterAction extends BaseAction
         'view' => null,
         'viewVar' => null,
         'entityKey' => 'entity',
+        'api' => [
+            'methods' => ['put', 'post'],
+            'success' => [
+                'code' => 201,
+                'data' => [
+                    'entity' => ['id']
+                ]
+            ],
+            'error' => [
+                'exception' => [
+                    'type' => 'validate',
+                    'class' => '\Crud\Error\Exception\ValidationException'
+                ]
+            ]
+        ],
         'messages' => [
             'success' => [
                 'text' => 'Account successfully created'

--- a/src/Action/ResetPasswordAction.php
+++ b/src/Action/ResetPasswordAction.php
@@ -29,6 +29,18 @@ class ResetPasswordAction extends BaseAction
         'relatedModels' => true,
         'saveOptions' => [],
         'view' => null,
+        'api' => [
+            'methods' => ['put', 'post'],
+            'success' => [
+                'code' => 200
+            ],
+            'error' => [
+                'exception' => [
+                    'type' => 'validate',
+                    'class' => '\Crud\Error\Exception\ValidationException'
+                ]
+            ]
+        ],
         'messages' => [
             'success' => [
                 'text' => 'Account updated successfully'

--- a/src/Action/VerifyAction.php
+++ b/src/Action/VerifyAction.php
@@ -30,6 +30,18 @@ class VerifyAction extends BaseAction
         'relatedModels' => true,
         'saveOptions' => [],
         'view' => null,
+        'api' => [
+            'methods' => ['put', 'post'],
+            'success' => [
+                'code' => 200
+            ],
+            'error' => [
+                'exception' => [
+                    'type' => 'validate',
+                    'class' => '\Crud\Error\Exception\ValidationException'
+                ]
+            ]
+        ],
         'messages' => [
             'success' => [
                 'text' => 'Account verified successfully'


### PR DESCRIPTION
Add default options for the api listener. If these options are not provided, the validation error messages are not returned in the api response.

I used http status code `201` (created) for Register, and the usual `200` (ok) for ResetPassword and Verify.

I did not allow the `patch` method by default, just to be consistent with Crud.Edit action.