### PR TITLE
Set the entity to null

### DIFF
--- a/src/Action/ForgotPasswordAction.php
+++ b/src/Action/ForgotPasswordAction.php
@@ -122,7 +122,7 @@ class ForgotPasswordAction extends BaseAction
      */
     protected function _error(Subject $subject)
     {
-        $subject->set(['success' => false]);
+        $subject->set(['success' => false, 'entity' => null]);
 
         $this->_trigger('afterForgotPassword', $subject);
         $this->setFlash('error', $subject);


### PR DESCRIPTION
The `ViewVarsTrait` expects at least a null entity to be set for the `beforeRender` trigger.