### PR TITLE
Allow adjustable token field name

### DIFF
--- a/src/Action/ForgotPasswordAction.php
+++ b/src/Action/ForgotPasswordAction.php
@@ -22,6 +22,7 @@ class ForgotPasswordAction extends BaseAction
         'scope' => 'entity',
         'findConfig' => [],
         'findMethod' => 'all',
+        'tokenField' => 'token',
         'messages' => [
             'success' => [
                 'text' => 'A recovery email has been sent successfully'

--- a/src/Action/VerifyAction.php
+++ b/src/Action/VerifyAction.php
@@ -26,6 +26,7 @@ class VerifyAction extends BaseAction
         'enabled' => true,
         'scope' => 'entity',
         'findMethod' => 'all',
+        'tokenField' => 'token',
         'saveMethod' => 'save',
         'relatedModels' => true,
         'saveOptions' => [],

--- a/src/Traits/VerifyTrait.php
+++ b/src/Traits/VerifyTrait.php
@@ -48,7 +48,7 @@ trait VerifyTrait
                 $this->findMethod(),
                 [
                     'token' => $token,
-                    'conditions' => [$this->_table()->aliasField('token') => $token]
+                    'conditions' => [$this->_table()->aliasField($this->config('tokenField')) => $token]
                 ]
             ),
         ]);


### PR DESCRIPTION
When using UseMuffin/Oauth one can't use "token" property name on UsersTable since it's using that in some callbacks - I guess it should be adjustable both places, but here's for a start :) 